### PR TITLE
feat: add support for ISO OSD XLSX comment imports

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -7,14 +7,18 @@ image:https://img.shields.io/github/commits-since/metanorma/commenter/latest.svg
 
 == Purpose
 
-Commenter is a Ruby gem for working with ISO comment sheets in DOCX format.
+Commenter is a Ruby gem for working with ISO comment sheets in DOCX and XLSX
+format.
 
 It provides utilities for parsing, manipulating, and serializing ISO comment
-data, converting between DOCX and structured YAML with schema validation.
+data, converting between DOCX/XLSX and structured YAML with schema validation.
 
-The format is taken from:
+The supported input formats are:
 
 * "ISO/IEC/CEN/CENELEC electronic balloting commenting template/version 2012-03"
+  (DOCX)
+* ISO Online Standards Development (OSD) XLSX exports (resolved and unresolved
+  comment sheets)
 
 This gem only supports plain text comment extraction and filling. Only use this
 to handle plain text comments and resolutions.
@@ -49,19 +53,27 @@ $ gem install commenter
 
 == Usage
 
-=== Importing comments from DOCX
+=== Importing comments
 
-Convert an ISO comment sheet DOCX file to structured YAML:
+Convert an ISO comment sheet (DOCX or XLSX) to structured YAML.
+The format is auto-detected from the file extension.
 
 [source,shell]
 ----
+# From DOCX (ISO 2012-03 template or OSD DOCX export)
 $ commenter import "ISO 80000-2 review comments.docx" -o comments.yaml
+
+# From XLSX (ISO OSD resolved comment export)
+$ commenter import "91855-Comments-resolved.xlsx" -o comments.yaml
+
+# From XLSX (ISO OSD comments-only export)
+$ commenter import "ISO 5843-6-Comments.xlsx" -o comments.yaml
 ----
 
 This will create two files:
 
 `comments.yaml`:: The structured comment data
-`schema/iso_comment_2012-03.yaml`:: The YAML schema for validation
+`schema/iso_comment_2012-03.yaml` or `schema/iso_comment_osd.yaml`:: The YAML schema for validation (selected automatically based on input format)
 
 ==== Import options
 
@@ -75,6 +87,10 @@ Options:
 `-o, --output FILE`:: Output YAML file (default: comments.yaml)
 `-e, --exclude-observations`:: Skip the observations column
 `--schema-dir DIR`:: Directory for schema file (default: schema)
+`--format FORMAT`:: Force input format (`docx` or `xlsx`; auto-detected by default)
+`--sheet NAME`:: XLSX sheet name to parse (default: first sheet)
+`--resolved-only`:: XLSX: use resolved comments sheet only
+`--unresolved-only`:: XLSX: use unresolved comments sheet only
 
 ==== Metadata (extraction limitation)
 
@@ -535,7 +551,8 @@ The comment types are defined as follows:
 [source,mermaid]
 ----
 flowchart LR
-    A[ISO Comment Sheet DOCX] --> B[commenter import]
+    A1[ISO Comment Sheet DOCX] --> B[commenter import]
+    A2[ISO OSD XLSX export] --> B
     B --> C[YAML + Schema]
     C --> D[commenter github-create]
     D --> E[YAML + GitHub Info]
@@ -566,6 +583,8 @@ recognized and applied to the observations column:
 
 == Data model
 
+=== ISO 2012-03 template (DOCX)
+
 The comment structure follows this schema:
 
 [source,yaml]
@@ -593,14 +612,61 @@ comments:           # Array of comment objects
       updated_at: string      # ISO 8601 timestamp (optional)
 ----
 
+=== ISO OSD format (XLSX)
 
-== Schema validation
-
-Each exported YAML file includes a schema reference for IDE support:
+The OSD format includes additional metadata and resolution fields extracted from
+the ISO Online Standards Development platform:
 
 [source,yaml]
 ----
+version: "osd"           # OSD format identifier
+date: string             # Date from XLSX header (auto-extracted)
+document: string         # Document reference, e.g. "ISO/DIS 5843-6(en)"
+project: string          # Project name (auto-extracted)
+stage: string            # Stage: WD, CD, DIS, FDIS, PRF, PUB (auto-extracted)
+title_en: string         # Document title in English (auto-extracted)
+title_fr: string         # Document title in French (auto-extracted)
+comments:
+  - id: string           # Comment ID (numeric from OSD)
+    body: string         # User name / member body
+    locality:
+      clause: string     # Clause number
+      element: string    # Clause title
+    type: "ge" | "te" | "ed"
+    comments: string     # Comment text
+    proposed_change: string
+    observations: string # Built from resolution_status + motivation
+    user_name: string         # OSD user name
+    comment_type: string      # Subtype: Editorial, General, Technical
+    resolution_status: string # Accepted, Partially accepted, Rejected, etc.
+    resolution_date: string   # Date resolved
+    feedbacks: string         # Discussion replies
+    motivation: string        # Resolution justification
+    created_date: string      # Date comment was created
+    stage_code: string        # ISO stage code (e.g. "40.20")
+----
+
+The OSD XLSX format comes in two variants, both auto-detected:
+
+*Resolved*: 17 columns starting with `Comment ID`, includes resolution data
+(`Resolution status`, `Motivation`, `Resolution Date`, `Stage code`)
+
+*Unresolved/comments-only*: 15 columns starting with `User name`, includes
+`Comment type`, `Comment/Motivation`, `Replies`, `Comment number`
+
+
+== Schema validation
+
+Each exported YAML file includes a schema reference for IDE support.
+The schema is selected automatically based on the input format:
+
+[source,yaml]
+----
+# For ISO 2012-03 DOCX imports:
 # yaml-language-server: $schema=schema/iso_comment_2012-03.yaml
+
+# For ISO OSD XLSX imports:
+# yaml-language-server: $schema=schema/iso_comment_osd.yaml
 ----
 
 This enables:
@@ -695,7 +761,8 @@ The gem is organized into several key components:
 
 `Commenter::Comment`:: Represents individual comments with locality, type, and content
 `Commenter::CommentSheet`:: Container for multiple comments with metadata
-`Commenter::Parser`:: Handles DOCX parsing and YAML generation
+`Commenter::Parser`:: Handles DOCX and XLSX parsing with auto-detection
+`Commenter::Parser::OsdXlsxParser`:: Parses ISO OSD XLSX exports (resolved and unresolved variants)
 `Commenter::Filler`:: Fills DOCX templates with comment data
 `Commenter::GitHubIssueCreator`:: Creates GitHub issues from comments
 
@@ -703,7 +770,7 @@ The gem is organized into several key components:
 
 `Commenter::Cli`:: Thor-based command-line interface with subcommands:
 
-** `import` - Convert DOCX to YAML
+** `import` - Convert DOCX or XLSX to YAML
 ** `fill` - Fill DOCX template from YAML
 ** `github-create` - Create GitHub issues from comments
 ** `github-retrieve` - Retrieve observations from GitHub issues
@@ -714,7 +781,8 @@ The gem is organized into several key components:
 * `data/github_issue_title_template.liquid` - GitHub issue title template
 * `data/github_issue_body_template.liquid` - GitHub issue body template
 * `data/github_config_sample.yaml` - Sample GitHub configuration
-* `schema/iso_comment_2012-03.yaml` - YAML schema for validation
+* `schema/iso_comment_2012-03.yaml` - YAML schema for ISO 2012-03 validation
+* `schema/iso_comment_osd.yaml` - YAML schema for ISO OSD format validation
 
 === Debugging
 

--- a/commenter.gemspec
+++ b/commenter.gemspec
@@ -35,5 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dotenv", "~> 2.8"
   spec.add_dependency "liquid", "~> 5.0"
   spec.add_dependency "octokit", "~> 6.0"
+  spec.add_dependency "roo", ">= 2.10"
   spec.add_dependency "thor", "~> 1.0"
 end

--- a/lib/commenter/cli.rb
+++ b/lib/commenter/cli.rb
@@ -9,37 +9,45 @@ require "commenter/github_integration"
 
 module Commenter
   class Cli < Thor
-    desc "import INPUT.docx", "Convert DOCX comment sheet to YAML"
+    desc "import INPUT", "Convert comment sheet (DOCX or XLSX) to YAML"
     option :output, type: :string, aliases: :o, default: "comments.yaml", desc: "Output YAML file"
     option :exclude_observations, type: :boolean, aliases: :e, desc: "Exclude observations column"
     option :schema_dir, type: :string, default: "schema", desc: "Directory for schema file"
-    def import(input_docx)
+    option :format, type: :string, desc: "Force input format (docx or xlsx)"
+    option :sheet, type: :string, desc: "XLSX sheet name to parse (default: first sheet)"
+    option :resolved_only, type: :boolean, desc: "XLSX: use resolved comments sheet only"
+    option :unresolved_only, type: :boolean, desc: "XLSX: use unresolved comments sheet only"
+    def import(input_file)
       output_yaml = options[:output]
       schema_dir = options[:schema_dir]
 
       # Ensure schema directory exists
       FileUtils.mkdir_p(schema_dir) unless Dir.exist?(schema_dir)
 
-      # Parse the DOCX file
+      # Parse the input file
       parser = Parser.new
-      comment_sheet = parser.parse(input_docx, options)
+      comment_sheet = parser.parse(input_file, options)
+
+      # Determine which schema to use based on version
+      schema_name = comment_sheet.version == "osd" ? "iso_comment_osd.yaml" : "iso_comment_2012-03.yaml"
 
       # Write the YAML data file with schema reference
-      yaml_content = generate_yaml_with_header(comment_sheet.to_yaml_h, schema_dir)
+      yaml_content = generate_yaml_with_header(comment_sheet.to_yaml_h, schema_dir, schema_name)
       File.write(output_yaml, yaml_content)
 
       # Copy schema file to output directory
-      schema_source = File.join(__dir__, "../../schema/iso_comment_2012-03.yaml")
-      schema_target = File.join(schema_dir, "iso_comment_2012-03.yaml")
+      schema_source = File.join(__dir__, "../../schema/#{schema_name}")
+      schema_target = File.join(schema_dir, schema_name)
 
       # Only copy if source and target are different
       unless File.expand_path(schema_source) == File.expand_path(schema_target)
-        FileUtils.cp(schema_source,
-                     schema_target)
+        FileUtils.cp(schema_source, schema_target)
       end
 
-      puts "Converted #{input_docx} to #{output_yaml}"
-      puts "Schema file created at #{schema_target}"
+      puts "Converted #{input_file} to #{output_yaml}"
+      puts "  Version: #{comment_sheet.version}"
+      puts "  Comments: #{comment_sheet.comments.length}"
+      puts "  Schema: #{schema_target}"
     end
 
     desc "fill INPUT.yaml", "Fill DOCX template from YAML comments"
@@ -209,8 +217,8 @@ module Commenter
 
     private
 
-    def generate_yaml_with_header(data, schema_dir)
-      schema_path = File.join(schema_dir, "iso_comment_2012-03.yaml")
+    def generate_yaml_with_header(data, schema_dir, schema_name = "iso_comment_2012-03.yaml")
+      schema_path = File.join(schema_dir, schema_name)
       header = "# yaml-language-server: $schema=#{schema_path}\n\n"
       header + data.to_yaml
     end

--- a/lib/commenter/comment.rb
+++ b/lib/commenter/comment.rb
@@ -2,7 +2,9 @@
 
 module Commenter
   class Comment
-    attr_accessor :id, :body, :locality, :type, :comments, :proposed_change, :observations, :github
+    attr_accessor :id, :body, :locality, :type, :comments, :proposed_change, :observations, :github,
+      :user_name, :comment_type, :resolution_status, :resolution_date, :feedbacks, :motivation,
+      :created_date, :stage_code
 
     def initialize(attributes = {})
       # Normalize input to symbols
@@ -16,6 +18,16 @@ module Commenter
       @proposed_change = attrs[:proposed_change]
       @observations = attrs[:observations]
       @github = symbolize_keys(attrs[:github] || {})
+
+      # OSD-specific fields
+      @user_name = attrs[:user_name]
+      @comment_type = attrs[:comment_type]
+      @resolution_status = attrs[:resolution_status]
+      @resolution_date = attrs[:resolution_date]
+      @feedbacks = attrs[:feedbacks]
+      @motivation = attrs[:motivation]
+      @created_date = attrs[:created_date]
+      @stage_code = attrs[:stage_code]
     end
 
     def expand_comment_type(type)
@@ -23,6 +35,9 @@ module Commenter
       when "ge" then "general"
       when "te" then "technical"
       when "ed" then "editorial"
+      when "general" then "ge"
+      when "technical" then "te"
+      when "editorial" then "ed"
       else type
       end
     end
@@ -117,6 +132,14 @@ module Commenter
         comments: @comments,
         proposed_change: @proposed_change,
         observations: @observations,
+        user_name: @user_name,
+        comment_type: @comment_type,
+        resolution_status: @resolution_status,
+        resolution_date: @resolution_date,
+        feedbacks: @feedbacks,
+        motivation: @motivation,
+        created_date: @created_date,
+        stage_code: @stage_code,
         github: @github.empty? ? nil : @github
       }.compact
     end

--- a/lib/commenter/comment_sheet.rb
+++ b/lib/commenter/comment_sheet.rb
@@ -4,7 +4,7 @@ require_relative "comment"
 
 module Commenter
   class CommentSheet
-    attr_accessor :version, :date, :document, :project, :stage, :comments
+    attr_accessor :version, :date, :document, :project, :stage, :comments, :title_en, :title_fr
 
     def initialize(attributes = {})
       # Normalize input to symbols
@@ -15,6 +15,8 @@ module Commenter
       @document = attrs[:document]
       @project = attrs[:project]
       @stage = attrs[:stage]
+      @title_en = attrs[:title_en]
+      @title_fr = attrs[:title_fr]
       @comments = (attrs[:comments] || []).map { |c| c.is_a?(Comment) ? c : Comment.from_hash(c) }
     end
 
@@ -29,12 +31,18 @@ module Commenter
         document: @document,
         project: @project,
         stage: @stage,
+        title_en: @title_en,
+        title_fr: @title_fr,
         comments: @comments.map(&:to_h)
       }
     end
 
     def to_yaml_h
-      stringify_keys(to_h.merge(comments: @comments.map(&:to_yaml_h)))
+      hash = to_h.merge(comments: @comments.map(&:to_yaml_h))
+      # Remove nil-valued keys for cleaner YAML output
+      hash.delete(:title_en) if hash[:title_en].nil?
+      hash.delete(:title_fr) if hash[:title_fr].nil?
+      stringify_keys(hash)
     end
 
     def self.from_hash(hash)

--- a/lib/commenter/parser.rb
+++ b/lib/commenter/parser.rb
@@ -1,12 +1,44 @@
 # frozen_string_literal: true
 
 require "docx"
+require "pathname"
 require_relative "comment_sheet"
 require_relative "comment"
+require_relative "parser/osd_xlsx_parser"
 
 module Commenter
   class Parser
-    def parse(docx_path, options = {})
+    def parse(input_path, options = {})
+      format = detect_format(input_path, options)
+
+      case format
+      when :docx
+        parse_docx(input_path, options)
+      when :xlsx
+        parse_xlsx(input_path, options)
+      else
+        raise "Unsupported file format: #{input_path}. Supported formats: .docx, .xlsx"
+      end
+    end
+
+    private
+
+    def detect_format(path, options = {})
+      return options[:format].to_sym if options[:format]
+
+      ext = File.extname(path).downcase
+      case ext
+      when ".docx" then :docx
+      when ".xlsx", ".xls" then :xlsx
+      else :unknown
+      end
+    end
+
+    def parse_xlsx(xlsx_path, options)
+      OsdXlsxParser.new.parse(xlsx_path, options)
+    end
+
+    def parse_docx(docx_path, options)
       doc = Docx::Document.open(docx_path)
 
       # Extract metadata from the first table
@@ -27,30 +59,57 @@ module Commenter
         # Skip only completely empty rows
         next if cells.all?(&:empty?)
 
-        # Extract body from ID (e.g., "DE-001" -> "DE")
-        id = cells[0] || ""
-        body = id.include?("-") ? id.split("-").first : id
+        # The DOCX from ISO OSD has 9 columns:
+        # 0: User name, 1: (empty/line), 2: Clause nb, 3: Clause Title,
+        # 4: Type, 5: Comment, 6: (empty/proposal), 7: Observations, 8: Comment number
+        # Detect format by checking if last column looks like a numeric ID
+        if cells.length >= 9 && cells[8] && cells[8].match?(/^\d+$/)
+          # ISO OSD DOCX format (9 columns)
+          id = cells[8]
+          body = cells[0].to_s.strip
+          comment_attrs = {
+            id: id,
+            body: body,
+            locality: {
+              clause: cells[2] && cells[2].empty? ? nil : cells[2],
+              element: cells[3] && cells[3].empty? ? nil : cells[3]
+            },
+            type: normalize_type(cells[4]),
+            comments: cells[5] || "",
+            proposed_change: cells[6] && cells[6].empty? ? nil : cells[6],
+            user_name: body
+          }
 
-        # Create comment with symbol keys, respecting all input data
-        comment_attrs = {
-          id: id,
-          body: body,
-          locality: {
-            line_number: cells[1] && cells[1].empty? ? nil : cells[1],
-            clause: cells[2] && cells[2].empty? ? nil : cells[2],
-            element: cells[3] && cells[3].empty? ? nil : cells[3]
-          },
-          type: cells[4] || "",
-          comments: cells[5] || "",
-          proposed_change: cells[6] || ""
-        }
+          unless options[:exclude_observations]
+            comment_attrs[:observations] = cells[7] && cells[7].empty? ? nil : cells[7]
+          end
 
-        # Handle observations column
-        unless options[:exclude_observations]
-          comment_attrs[:observations] = cells[7] && cells[7].empty? ? nil : cells[7]
+          comments << Comment.new(comment_attrs)
+        else
+          # Classic ISO comment template format (8 columns)
+          # 0: ID, 1: line_number, 2: clause, 3: element, 4: type, 5: comments, 6: proposed_change, 7: observations
+          id = cells[0] || ""
+          body = id.include?("-") ? id.split("-").first : id
+
+          comment_attrs = {
+            id: id,
+            body: body,
+            locality: {
+              line_number: cells[1] && cells[1].empty? ? nil : cells[1],
+              clause: cells[2] && cells[2].empty? ? nil : cells[2],
+              element: cells[3] && cells[3].empty? ? nil : cells[3]
+            },
+            type: cells[4] || "",
+            comments: cells[5] || "",
+            proposed_change: cells[6] || ""
+          }
+
+          unless options[:exclude_observations]
+            comment_attrs[:observations] = cells[7] && cells[7].empty? ? nil : cells[7]
+          end
+
+          comments << Comment.new(comment_attrs)
         end
-
-        comments << Comment.new(comment_attrs)
       end
 
       # Create comment sheet
@@ -63,7 +122,14 @@ module Commenter
       )
     end
 
-    private
+    def normalize_type(type_str)
+      case type_str.to_s.strip.downcase
+      when "editorial" then "ed"
+      when "technical" then "te"
+      when "general" then "ge"
+      else type_str.to_s.strip
+      end
+    end
 
     def extract_metadata(doc)
       metadata = { date: nil, document: nil, project: nil }
@@ -95,9 +161,6 @@ module Commenter
       # Look for project patterns
       project_match = all_text.match(/Project:\s*([^\n\r]+)/)
       metadata[:project] = project_match[1]&.strip if project_match
-
-      # If no metadata found, try to extract from filename or other sources
-      # This is a fallback - in practice, users might need to provide metadata manually
 
       metadata
     end

--- a/lib/commenter/parser/osd_xlsx_parser.rb
+++ b/lib/commenter/parser/osd_xlsx_parser.rb
@@ -1,0 +1,402 @@
+# frozen_string_literal: true
+
+require "roo"
+require_relative "../comment_sheet"
+require_relative "../comment"
+
+module Commenter
+  class Parser
+    # Parser for ISO Online Standards Development (OSD) XLSX exports.
+    #
+    # Supports two variants:
+    #   - "resolved" XLSX: single "Comments (N)" sheet with resolution data
+    #     (columns: Comment ID, User name, Clause nb, ..., Resolution status, Motivation, Resolution Date, Stage code)
+    #   - "unresolved" XLSX: multi-sheet format with "Comments (N)", "Unresolved comments (N)",
+    #     "Resolved comments (N)" sheets
+    #     (columns: User name, Clause nb, ..., Comment type, Comment/Motivation, Comment on text,
+    #      Proposal on Text, Proposed change, Replies, Resolution status, Justification, Resolution Date, Date, Comment number)
+    #
+    # Both formats share the same header structure in rows 0-3:
+    #   Row 0: [Date, Reference, nil, "", Title EN, nil, nil, Title FR, ...]
+    #   Row 1: ["2026-04-21", "ISO/DIS 5843-6(en)", ...]
+    #   Row 2: empty
+    #   Row 3: column headers
+    #   Row 4+: data
+    class OsdXlsxParser
+      RESOLVED_HEADERS = [
+        "Comment ID", "User name", "Clause nb", "Clause Title", "Type", "Subtype",
+        "Comment", "Proposal on Text", "Proposed change", "Feedbacks", "Topic",
+        "Tags", "Created Date", "Resolution status", "Motivation", "Resolution Date", "Stage code"
+      ].freeze
+
+      UNRESOLVED_HEADERS = [
+        "User name", "Clause nb", "Clause Title", "Type", "Comment type",
+        "Comment/Motivation", "Comment on text", "Proposal on Text", "Proposed change",
+        "Replies", "Resolution status", "Justification", "Resolution Date", "Date", "Comment number"
+      ].freeze
+
+      def parse(xlsx_path, options = {})
+        xlsx = Roo::Spreadsheet.open(xlsx_path)
+
+        # Select which sheet(s) to use
+        sheet_name = select_sheet(xlsx, options)
+
+        # Detect variant from header row
+        sheet = xlsx.sheet(sheet_name)
+        header_row_num = find_header_row(sheet)
+        header_row_data = sheet.row(header_row_num)
+        variant = detect_variant(header_row_data)
+
+        # Extract metadata from the header rows
+        metadata = extract_metadata(xlsx, sheet_name, header_row_num)
+
+        # Parse comments based on variant
+        comments = if variant == :resolved
+                     parse_resolved_sheet(sheet, header_row_num, options)
+                   else
+                     parse_unresolved_sheet(sheet, header_row_num, options)
+                   end
+
+        CommentSheet.new(
+          version: "osd",
+          date: metadata[:date],
+          document: metadata[:document],
+          project: metadata[:project],
+          stage: metadata[:stage],
+          title_en: metadata[:title_en],
+          title_fr: metadata[:title_fr],
+          comments: comments
+        )
+      end
+
+      private
+
+      def select_sheet(xlsx, options)
+        sheets = xlsx.sheets
+
+        if options[:sheet]
+          # Explicit sheet name
+          raise "Sheet '#{options[:sheet]}' not found. Available: #{sheets.join(', ')}" unless sheets.include?(options[:sheet])
+          options[:sheet]
+        elsif options[:resolved_only]
+          sheets.find { |s| s.start_with?("Resolved") } || sheets.find { |s| s.start_with?("Comments") }
+        elsif options[:unresolved_only]
+          sheets.find { |s| s.start_with?("Unresolved") } || sheets.find { |s| s.start_with?("Comments") }
+        else
+          # Default: use first sheet (usually "Comments (N)" which has all comments)
+          sheets.first
+        end
+      end
+
+      def find_header_row(sheet)
+        # Headers are always in row 4 (1-indexed in Roo), which is the 4th row (index 3)
+        # But we search for it to be safe
+        (1..10).each do |row_num|
+          row = sheet.row(row_num).compact.map(&:to_s)
+          return row_num if row.include?("User name") || row.include?("Comment ID")
+        end
+        raise "Could not find header row in XLSX sheet"
+      end
+
+      def detect_variant(header_row)
+        row = header_row.compact.map(&:to_s)
+        if row.include?("Comment ID") || row.include?("Subtype")
+          :resolved
+        elsif row.include?("Comment/Motivation") || row.include?("Comment type")
+          :unresolved
+        else
+          # Try to infer from column count
+          row.length >= 15 ? :resolved : :unresolved
+        end
+      end
+
+      def extract_metadata(xlsx, sheet_name, header_row_num)
+        metadata = { date: nil, document: nil, project: nil, stage: nil, title_en: nil, title_fr: nil }
+
+        # Row 1 (1-indexed) contains header labels: [Date, Reference, nil, "", Title EN, nil, nil, Title FR, ...]
+        # Row 2 (1-indexed) contains values: [2026-04-21, ISO/DIS 5843-6(en), nil, "", ...]
+        # We read raw rows (not compact) to preserve column positions
+        row1 = xlsx.sheet(sheet_name).row(1)
+        row2 = xlsx.sheet(sheet_name).row(2)
+
+        # Date is in column 0 of row 2 (the value row)
+        date_val = row2 && row2[0]
+        date_str = date_val.is_a?(Date) ? date_val.strftime("%Y-%m-%d") : date_val.to_s.strip
+        metadata[:date] = date_str if date_str && !date_str.empty? && date_str != "Date"
+
+        # Reference is in column 1 of row 2 (e.g. "ISO/DIS 5843-6(en)")
+        reference = row2 && row2[1] ? row2[1].to_s.strip : nil
+        if reference && !reference.empty? && reference != "Reference"
+          metadata[:document] = reference
+          metadata[:stage] = extract_stage(reference)
+          metadata[:project] = extract_project(reference)
+        end
+
+        # Title EN is in column 4 of row 2
+        title_en = row2 && row2[4] ? row2[4].to_s.strip : nil
+        metadata[:title_en] = title_en if title_en && !title_en.empty? && title_en != "Title EN"
+
+        # Title FR is in column 7 of row 2
+        title_fr = row2 && row2[7] ? row2[7].to_s.strip : nil
+        metadata[:title_fr] = title_fr if title_fr && !title_fr.empty? && title_fr != "Title FR"
+
+        metadata
+      end
+
+      def parse_date(date_str)
+        case date_str
+        when /^\d{4}-\d{2}-\d{2}$/
+          date_str
+        when /(\d{4})-(\d{2})-(\d{2})/
+          $&
+        else
+          date_str
+        end
+      rescue StandardError
+        date_str
+      end
+
+      def extract_stage(reference)
+        case reference
+        when /\/WD\b/i then "WD"
+        when /\/CD\b/i then "CD"
+        when /\/DIS\b/i then "DIS"
+        when /\/FDIS\b/i then "FDIS"
+        else nil
+        end
+      end
+
+      def extract_project(reference)
+        # Extract ISO number from reference like "ISO/DIS 5843-6(en)"
+        match = reference.match(/(ISO[\s\/]*\w*\s*\d+[\-\d]*)/)
+        match ? match[1].strip.gsub(/\s+/, " ") : nil
+      end
+
+      def parse_resolved_sheet(sheet, header_row_num, options)
+        # Build column index map from header
+        headers = sheet.row(header_row_num).compact.map { |h| h.to_s.strip }
+        col_map = build_resolved_column_map(headers)
+
+        comments = []
+        (header_row_num + 1..sheet.last_row).each do |row_num|
+          row = sheet.row(row_num)
+          next if row.nil? || row.compact.empty?
+
+          comment = build_resolved_comment(row, col_map, options)
+          comments << comment if comment
+        end
+
+        comments
+      end
+
+      def parse_unresolved_sheet(sheet, header_row_num, options)
+        # Build column index map from header
+        headers = sheet.row(header_row_num).compact.map { |h| h.to_s.strip }
+        col_map = build_unresolved_column_map(headers)
+
+        comments = []
+        (header_row_num + 1..sheet.last_row).each do |row_num|
+          row = sheet.row(row_num)
+          next if row.nil? || row.compact.empty?
+
+          comment = build_unresolved_comment(row, col_map, options)
+          comments << comment if comment
+        end
+
+        comments
+      end
+
+      def build_resolved_column_map(headers)
+        map = {}
+        headers.each_with_index do |h, i|
+          case h
+          when "Comment ID" then map[:id] = i
+          when "User name" then map[:user_name] = i
+          when "Clause nb" then map[:clause] = i
+          when "Clause Title" then map[:clause_title] = i
+          when "Type" then map[:type] = i
+          when "Subtype" then map[:subtype] = i
+          when "Comment" then map[:comment_text] = i
+          when "Proposal on Text" then map[:proposal_on_text] = i
+          when "Proposed change" then map[:proposed_change] = i
+          when "Feedbacks" then map[:feedbacks] = i
+          when "Topic" then map[:topic] = i
+          when "Tags" then map[:tags] = i
+          when "Created Date" then map[:created_date] = i
+          when "Resolution status" then map[:resolution_status] = i
+          when "Motivation" then map[:motivation] = i
+          when "Resolution Date" then map[:resolution_date] = i
+          when "Stage code" then map[:stage_code] = i
+          end
+        end
+        map
+      end
+
+      def build_unresolved_column_map(headers)
+        map = {}
+        headers.each_with_index do |h, i|
+          case h
+          when "User name" then map[:user_name] = i
+          when "Clause nb" then map[:clause] = i
+          when "Clause Title" then map[:clause_title] = i
+          when "Type" then map[:type] = i
+          when "Comment type" then map[:comment_type] = i
+          when "Comment/Motivation" then map[:comment_text] = i
+          when "Comment on text" then map[:comment_on_text] = i
+          when "Proposal on Text" then map[:proposal_on_text] = i
+          when "Proposed change" then map[:proposed_change] = i
+          when "Replies" then map[:replies] = i
+          when "Resolution status" then map[:resolution_status] = i
+          when "Justification" then map[:justification] = i
+          when "Resolution Date" then map[:resolution_date] = i
+          when "Date" then map[:created_date] = i
+          when "Comment number" then map[:id] = i
+          end
+        end
+        map
+      end
+
+      def build_resolved_comment(row, col_map, options)
+        id = cell_value(row, col_map[:id])
+        return nil if id.nil?
+
+        # Normalize id to string
+        id_str = id.is_a?(Float) ? id.to_i.to_s : id.to_s
+
+        comment_text = cell_value(row, col_map[:comment_text]) || ""
+        return nil if comment_text.strip.empty? && id_str.empty?
+
+        clause = cell_value(row, col_map[:clause]) || ""
+        clause_title = cell_value(row, col_map[:clause_title]) || ""
+        subtype = cell_value(row, col_map[:subtype]) || ""
+
+        # Combine clause number and title for locality
+        clause_ref = clause.to_s.strip
+        clause_ref = "#{clause_ref} #{clause_title}".strip if clause_title && !clause_title.empty?
+
+        user_name = cell_value(row, col_map[:user_name]) || ""
+        body = user_name.to_s.strip
+
+        comment_attrs = {
+          id: id_str,
+          body: body,
+          locality: {
+            clause: clause.empty? ? nil : clause.to_s.strip,
+            element: clause_title.empty? ? nil : clause_title.to_s.strip
+          }.compact,
+          type: normalize_comment_type(subtype),
+          comments: comment_text.to_s.strip,
+          proposed_change: cell_value_str(row, col_map[:proposed_change]) ||
+                           cell_value_str(row, col_map[:proposal_on_text]),
+          observations: nil
+        }
+
+        # OSD-specific fields
+        comment_attrs[:user_name] = user_name.to_s.strip
+        comment_attrs[:comment_type] = subtype.to_s.strip
+        comment_attrs[:resolution_status] = cell_value_str(row, col_map[:resolution_status])
+        comment_attrs[:resolution_date] = cell_value_str(row, col_map[:resolution_date])
+        comment_attrs[:feedbacks] = cell_value_str(row, col_map[:feedbacks])
+        comment_attrs[:motivation] = cell_value_str(row, col_map[:motivation])
+        comment_attrs[:created_date] = cell_value_str(row, col_map[:created_date])
+        comment_attrs[:stage_code] = cell_value_str(row, col_map[:stage_code])
+
+        # Build observations from resolution data
+        unless options[:exclude_observations]
+          observations_parts = []
+          if comment_attrs[:resolution_status] && !comment_attrs[:resolution_status].empty?
+            observations_parts << comment_attrs[:resolution_status]
+          end
+          if comment_attrs[:motivation] && !comment_attrs[:motivation].empty?
+            observations_parts << comment_attrs[:motivation]
+          end
+          comment_attrs[:observations] = observations_parts.empty? ? nil : observations_parts.join(". ")
+        end
+
+        Comment.new(comment_attrs)
+      end
+
+      def build_unresolved_comment(row, col_map, options)
+        id = cell_value(row, col_map[:id])
+        return nil if id.nil?
+
+        # Normalize id to string
+        id_str = id.is_a?(Float) ? id.to_i.to_s : id.to_s
+
+        comment_text = cell_value(row, col_map[:comment_text]) || ""
+        return nil if comment_text.strip.empty? && id_str.empty?
+
+        clause = cell_value(row, col_map[:clause]) || ""
+        clause_title = cell_value(row, col_map[:clause_title]) || ""
+        comment_type = cell_value(row, col_map[:comment_type]) || ""
+
+        user_name = cell_value(row, col_map[:user_name]) || ""
+        body = user_name.to_s.strip
+
+        comment_attrs = {
+          id: id_str,
+          body: body,
+          locality: {
+            clause: clause.empty? ? nil : clause.to_s.strip,
+            element: clause_title.empty? ? nil : clause_title.to_s.strip
+          }.compact,
+          type: normalize_comment_type(comment_type),
+          comments: comment_text.to_s.strip,
+          proposed_change: cell_value_str(row, col_map[:proposed_change]) ||
+                           cell_value_str(row, col_map[:proposal_on_text]),
+          observations: nil
+        }
+
+        # OSD-specific fields
+        comment_attrs[:user_name] = user_name.to_s.strip
+        comment_attrs[:comment_type] = comment_type.to_s.strip
+        comment_attrs[:resolution_status] = cell_value_str(row, col_map[:resolution_status])
+        comment_attrs[:resolution_date] = cell_value_str(row, col_map[:resolution_date])
+        comment_attrs[:feedbacks] = cell_value_str(row, col_map[:replies])
+        comment_attrs[:motivation] = cell_value_str(row, col_map[:justification])
+        comment_attrs[:created_date] = cell_value_str(row, col_map[:created_date])
+
+        # Build observations from resolution data
+        unless options[:exclude_observations]
+          observations_parts = []
+          if comment_attrs[:resolution_status] && !comment_attrs[:resolution_status].empty?
+            observations_parts << comment_attrs[:resolution_status]
+          end
+          if comment_attrs[:motivation] && !comment_attrs[:motivation].empty?
+            observations_parts << comment_attrs[:motivation]
+          end
+          comment_attrs[:observations] = observations_parts.empty? ? nil : observations_parts.join(". ")
+        end
+
+        Comment.new(comment_attrs)
+      end
+
+      def normalize_comment_type(type_str)
+        case type_str.to_s.strip.downcase
+        when "editorial" then "ed"
+        when "technical" then "te"
+        when "general" then "ge"
+        when "ed" then "ed"
+        when "te" then "te"
+        when "ge" then "ge"
+        else type_str.to_s.strip
+        end
+      end
+
+      def cell_value(row, index)
+        return nil if index.nil?
+        return nil if row.length <= index
+
+        val = row[index]
+        return nil if val.is_a?(String) && val.strip.empty?
+        val
+      end
+
+      def cell_value_str(row, index)
+        val = cell_value(row, index)
+        return nil if val.nil?
+        val.to_s.strip.empty? ? nil : val.to_s.strip
+      end
+    end
+  end
+end

--- a/schema/iso_comment_osd.yaml
+++ b/schema/iso_comment_osd.yaml
@@ -1,0 +1,112 @@
+# ISO Comment Schema for ISO Online Standards Development (OSD) format
+# Supports both resolved and unresolved XLSX exports from ISO OSD
+$schema: http://json-schema.org/draft-07/schema#
+title: ISO Comment OSD
+description: Schema for ISO comments exported from ISO Online Standards Development (OSD) platform
+type: object
+properties:
+  version:
+    type: string
+    const: "osd"
+    description: Version identifier for OSD format
+  date:
+    type: ["string", "null"]
+    description: Date from the XLSX header
+    format: date
+  document:
+    type: ["string", "null"]
+    description: Document reference (e.g. ISO/DIS 5843-6(en))
+  project:
+    type: ["string", "null"]
+    description: Project name
+  title_en:
+    type: ["string", "null"]
+    description: Document title in English
+  title_fr:
+    type: ["string", "null"]
+    description: Document title in French
+  stage:
+    type: ["string", "null"]
+    description: Approval stage (WD/CD/DIS/FDIS/PRF/PUB)
+    enum: [null, "WD", "CD", "DIS", "FDIS", "PRF", "PUB"]
+  comments:
+    type: array
+    description: Array of comment entries from the ISO OSD export
+    items:
+      type: object
+      properties:
+        id:
+          type: ["string", "number"]
+          description: "Comment ID (numeric from OSD)"
+        body:
+          type: ["string", "null"]
+          description: "Member body or user name"
+        locality:
+          type: object
+          description: "Location information for the comment"
+          properties:
+            line_number:
+              type: ["string", "null"]
+            clause:
+              type: ["string", "null"]
+            element:
+              type: ["string", "null"]
+              description: "Clause Title from OSD"
+        type:
+          type: ["string", "null"]
+          description: "Type of comment (ge/te/ed)"
+          enum: [null, "ge", "te", "ed"]
+        comments:
+          type: ["string", "null"]
+          description: "The comment text"
+        proposed_change:
+          type: ["string", "null"]
+          description: "Proposed change text"
+        observations:
+          type: ["string", "null"]
+          description: "Resolution status or observations"
+        user_name:
+          type: ["string", "null"]
+          description: "User name from OSD"
+        comment_type:
+          type: ["string", "null"]
+          description: "Comment type/subtype from OSD (e.g. Editorial, General, Technical)"
+        resolution_status:
+          type: ["string", "null"]
+          description: "Resolution status (Accepted, Partially accepted, Rejected, etc.)"
+        resolution_date:
+          type: ["string", "null"]
+          description: "Date when the comment was resolved"
+        feedbacks:
+          type: ["string", "null"]
+          description: "Feedback/replies from the discussion"
+        motivation:
+          type: ["string", "null"]
+          description: "Motivation/justification for resolution"
+        created_date:
+          type: ["string", "null"]
+          description: "Date when the comment was created"
+        stage_code:
+          type: ["string", "null"]
+          description: "ISO stage code (e.g. 40.20)"
+        github:
+          type: ["object", "null"]
+          description: "GitHub integration information"
+          properties:
+            issue_number:
+              type: integer
+            issue_url:
+              type: string
+              format: uri
+            status:
+              type: string
+              enum: ["open", "closed"]
+            created_at:
+              type: string
+              format: date-time
+            updated_at:
+              type: string
+              format: date-time
+          required: ["issue_number", "issue_url", "status"]
+      required: ["id", "locality", "comments"]
+required: ["version", "comments"]


### PR DESCRIPTION
## Summary

- Add parser for ISO Online Standards Development (OSD) XLSX exports, supporting both resolved (17-column) and unresolved/comments-only (15-column) variants
- The `import` command now auto-detects input format (DOCX or XLSX) by file extension
- OSD XLSX metadata (date, document, stage, titles) is automatically extracted from header rows
- Extend the Comment/CommentSheet data model with OSD-specific fields (user_name, resolution_status, resolution_date, feedbacks, motivation, created_date, stage_code)
- Update the existing DOCX parser to handle both classic 8-column and OSD 9-column formats
- Add `roo` gem dependency for XLSX parsing

## Supported formats

| Format | File | Columns | Status |
|--------|------|---------|--------|
| ISO 2012-03 DOCX | Classic comment template | 8 | Existing |
| ISO OSD DOCX | OSD comment export | 9 | New (auto-detected) |
| ISO OSD XLSX (resolved) | Resolved comments | 17 | New |
| ISO OSD XLSX (unresolved) | Comments-only | 15 | New |

## New CLI options for `import`

- `--format FORMAT` — Force input format (docx/xlsx)
- `--sheet NAME` — XLSX sheet name to parse
- `--resolved-only` — Use resolved comments sheet only
- `--unresolved-only` — Use unresolved comments sheet only

## Test plan

- [x] All 38 existing tests pass
- [x] Tested with OSD DOCX (9-col): `91855-20260421-Comments.docx`
- [x] Tested with OSD XLSX resolved: `91855-20260421-Comments-resolved.xlsx`
- [x] Tested with OSD XLSX comments-only: `ISO 5843-6-Comments.xlsx`
- [x] Tested with OSD XLSX unresolved variant: `91855-20260305-Comments-resolved.xlsx`
- [x] Tested with classic ISO DOCX: `UK_Comments_CD_2533_.docx`
- [x] YAML output validated against schemas for both formats